### PR TITLE
replaced esp_panic.h to get rid of the deprecated warnings

### DIFF
--- a/ssd1306_err.h
+++ b/ssd1306_err.h
@@ -2,7 +2,9 @@
 #define _SSD1306_ERR_H_
 
 #include <esp_log.h>
-#include <esp_panic.h>
+#include <esp_debug_helpers.h>
+#include <esp_private/panic_reason.h>
+
 
 #if CONFIG_SSD1306_ERROR_ABORT
     #define SSD1306_DoAbort( ) abort( )


### PR DESCRIPTION
Using esp_panic.h gives of warning messages during compilation. Replacing esp_panic.h with esp_debug_helpers.h and esp_private/panic_reason.h prevents the warnings. This is the solution propagated in esp_panic.h.